### PR TITLE
Use letters instead of numbers as the suffix for arg variables

### DIFF
--- a/src/Internal/Builtin/Codec.elm
+++ b/src/Internal/Builtin/Codec.elm
@@ -2,6 +2,7 @@ module Internal.Builtin.Codec exposing (codeGen)
 
 import CodeGenerator exposing (CodeGenerator)
 import Elm.CodeGen as CG
+import Internal.Helpers
 import ResolvedType
 import String.Extra
 import TypePattern exposing (TypePattern(..))
@@ -75,9 +76,9 @@ codeGen =
 
 thingsToPatterns : List a -> List CG.Pattern
 thingsToPatterns =
-    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ Internal.Helpers.intToLetter i))
 
 
 thingsToValues : List a -> List CG.Expression
 thingsToValues =
-    List.indexedMap (\i _ -> CG.val ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.val ("arg" ++ Internal.Helpers.intToLetter i))

--- a/src/Internal/Builtin/JsonEncoder.elm
+++ b/src/Internal/Builtin/JsonEncoder.elm
@@ -83,7 +83,7 @@ codeGen =
                                         [ CG.fqFun [ "Json", "Encode" ] "object"
                                         , CG.list
                                             (CG.tuple [ CG.string "tag", CG.apply [ CG.fqFun [ "Json", "Encode" ] "string", CG.string ref.name ] ]
-                                                :: List.indexedMap (\i expr -> CG.tuple [ CG.string (String.fromInt i), CG.apply [ expr, CG.val ("arg" ++ String.fromInt i) ] ]) exprs
+                                                :: List.indexedMap (\i expr -> CG.tuple [ CG.string (String.fromInt i), CG.apply [ expr, CG.val ("arg" ++ Internal.Helpers.intToLetter i) ] ]) exprs
                                             )
                                         ]
                                     )
@@ -159,9 +159,9 @@ codeGen =
 
 thingsToPatterns : List a -> List CG.Pattern
 thingsToPatterns =
-    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ Internal.Helpers.intToLetter i))
 
 
 thingsToValues : List a -> List CG.Expression
 thingsToValues =
-    List.indexedMap (\i _ -> CG.val ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.val ("arg" ++ Internal.Helpers.intToLetter i))

--- a/src/Internal/Builtin/MiniBillCodec.elm
+++ b/src/Internal/Builtin/MiniBillCodec.elm
@@ -2,6 +2,7 @@ module Internal.Builtin.MiniBillCodec exposing (codeGen)
 
 import CodeGenerator exposing (CodeGenerator)
 import Elm.CodeGen as CG
+import Internal.Helpers
 import ResolvedType
 import String.Extra
 import TypePattern exposing (TypePattern(..))
@@ -119,9 +120,9 @@ codeGen =
 
 thingsToPatterns : List a -> List CG.Pattern
 thingsToPatterns =
-    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.varPattern ("arg" ++ Internal.Helpers.intToLetter i))
 
 
 thingsToValues : List a -> List CG.Expression
 thingsToValues =
-    List.indexedMap (\i _ -> CG.val ("arg" ++ String.fromInt i))
+    List.indexedMap (\i _ -> CG.val ("arg" ++ Internal.Helpers.intToLetter i))

--- a/src/Internal/Helpers.elm
+++ b/src/Internal/Helpers.elm
@@ -1,4 +1,4 @@
-module Internal.Helpers exposing (applyBindings, hasDebugTodo, lambda1, node, rangeContains, traverseExpression, traversePattern, traverseTypeAnnotation, writeExpression)
+module Internal.Helpers exposing (applyBindings, hasDebugTodo, intToLetter, lambda1, node, rangeContains, traverseExpression, traversePattern, traverseTypeAnnotation, writeExpression)
 
 import Dict
 import Elm.CodeGen as CG
@@ -373,3 +373,18 @@ traversePattern fn initial pattern =
 
         _ ->
             ( newPattern, accumulator )
+
+
+lettersInAlphabet =
+    26
+
+
+intToLetter : Int -> String
+intToLetter int =
+    (if int < lettersInAlphabet then
+        ""
+
+     else
+        String.fromChar (Char.fromCode (65 - 1 + int // lettersInAlphabet))
+    )
+        ++ String.fromChar (Char.fromCode (65 + modBy lettersInAlphabet int))

--- a/src/Internal/Helpers.elm
+++ b/src/Internal/Helpers.elm
@@ -375,6 +375,7 @@ traversePattern fn initial pattern =
             ( newPattern, accumulator )
 
 
+lettersInAlphabet : number
 lettersInAlphabet =
     26
 

--- a/tests/HelperTest.elm
+++ b/tests/HelperTest.elm
@@ -1,0 +1,24 @@
+module HelperTest exposing (suite)
+
+import Expect
+import Internal.Helpers
+import Test exposing (Test)
+
+
+suite : Test
+suite =
+    Test.describe "intToLetter"
+        (List.map
+            (\( input, expected ) ->
+                Test.test (String.fromInt input ++ " -> " ++ expected) <|
+                    \_ -> Internal.Helpers.intToLetter input |> Expect.equal expected
+            )
+            [ ( 0, "A" )
+            , ( 25, "Z" )
+            , ( 26, "AA" )
+            , ( 51, "AZ" )
+            , ( 52, "BA" )
+            , ( 53, "BB" )
+            , ( 701, "ZZ" )
+            ]
+        )

--- a/tests/IncrementalTests.elm
+++ b/tests/IncrementalTests.elm
@@ -158,11 +158,11 @@ type Foo
 encode : Foo -> Value
 encode foo =
     case foo of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int argA ) ]
 
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.string arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.string argA ) ]
 """
         , codeGenIncrementalTest "Picks up an encoder from another file"
             [ elmJson ]
@@ -200,8 +200,8 @@ type B =
 encode : B -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode argA ) ]
 """
         , codeGenIncrementalTest "Picks up a generator from another file with different import notation"
             [ elmJson ]
@@ -239,8 +239,8 @@ type B =
 encode : B -> Encode.Value
 encode b =
     case b of
-        B arg0 ->
-            Encode.object [ ( "tag", Encode.string "B" ), ( "0", A.encode arg0 ) ]
+        B argA ->
+            Encode.object [ ( "tag", Encode.string "B" ), ( "0", A.encode argA ) ]
 """
         , codeGenIncrementalTest "Picks up an encoder from another file with generics"
             [ elmJson ]
@@ -278,8 +278,8 @@ type B =
 encode : B -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int argA ) ]
 """
         , codeGenIncrementalTest "Picks up an encoder from another file with generics type alias"
             [ elmJson ]
@@ -317,8 +317,8 @@ type B =
 encode : B Int -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int argA ) ]
 """
         , codeGenIncrementalTest "Doesn't pick up an encoder if not exposed"
             [ elmJson ]
@@ -356,8 +356,8 @@ type B =
 encode : B -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA Json.Encode.int argA ) ]
 
 encodeA : (a -> Value) -> A a -> Value
 encodeA a =
@@ -397,8 +397,8 @@ type C =
 encode : C -> Value
 encode c =
     case c of
-        C arg0 arg1 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "C" ), ( "0", encodeA arg0 ), ( "1", encodeB arg1 ) ]
+        C argA argB ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "C" ), ( "0", encodeA argA ), ( "1", encodeB argB ) ]
 
 encodeA : A -> Value
 encodeA =
@@ -450,8 +450,8 @@ type Foo =
 encode : Foo -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA argA ) ]
 
 encodeA : A -> Value
 encodeA =
@@ -491,8 +491,8 @@ type Foo =
 encode : Foo -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA argA ) ]
 
 encodeA : A -> Value
 encodeA =
@@ -524,8 +524,8 @@ type A =
 encode : A -> Value
 encode arg =
     case arg of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int argA ) ]
 
 main =
     Json.Encode.encode 2 (encode (A 2))
@@ -547,11 +547,11 @@ encode encodeVal a =
 encodeResult : (err -> Value) -> (ok -> Value) -> Result err ok -> Value
 encodeResult err ok val =
     case val of
-        Err arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err arg0 ) ]
+        Err argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err argA ) ]
 
-        Ok arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok arg0 ) ]
+        Ok argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok argA ) ]
 """ ]
             """module A exposing (A, encode)
 import Json.Encode exposing (Value)
@@ -563,18 +563,18 @@ type A
 encode : A val -> Value
 encode encodeVal a =
     case a of
-        A arg0 ->
+        A argA ->
             Json.Encode.object
-                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int arg0 ) ]
+                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int argA ) ]
 
 encodeResult : (err -> Value) -> (ok -> Value) -> Result err ok -> Value
 encodeResult err ok val =
     case val of
-        Err arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err arg0 ) ]
+        Err argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err argA ) ]
 
-        Ok arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok arg0 ) ]
+        Ok argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok argA ) ]
 """
         , codeGenIncrementalTest "Picks up the definition of Result from dependency"
             [ elmJson ]
@@ -600,9 +600,9 @@ type A
 encode : A val -> Value
 encode encodeVal a =
     case a of
-        A arg0 ->
+        A argA ->
             Json.Encode.object
-                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int arg0 ) ]
+                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int argA ) ]
 
 encodeResult : (error -> Value) -> (value -> Value) -> Result error value -> Value
 encodeResult error value =
@@ -636,8 +636,8 @@ type B
 encode : A -> Value
 encode arg =
     case arg of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB argA ) ]
 
 encodeB : B -> Value
 encodeB =
@@ -667,12 +667,12 @@ type Tree a
 encode : (a -> Value) -> Tree a -> Value
 encode childEncoder tree =
     case tree of
-        Node arg0 arg1 arg2 ->
+        Node argA argB argC ->
             Encode.object
                 [ ( "tag", Encode.string "Node" )
-                , ( "0", encode childEncoder arg0 )
-                , ( "1", childEncoder arg1 )
-                , ( "2", encode childEncoder arg2 )
+                , ( "0", encode childEncoder argA )
+                , ( "1", childEncoder argB )
+                , ( "2", encode childEncoder argC )
                 ]
 
         Empty ->
@@ -800,8 +800,8 @@ type Always =
 encode : Foo { capabilites | x : Always } -> Value
 encode foo =
     case foo of
-        Foo arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Foo" ), ( "0", Json.Encode.int arg0 ) ]
+        Foo argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Foo" ), ( "0", Json.Encode.int argA ) ]
 """
         , codeGenIncrementalTest "Generates an encoder with a list"
             [ elmJson ]
@@ -916,14 +916,14 @@ import Json.Encode exposing (Value)
 encode : A Int -> Value
 encode arg =
     case arg of
-        Rec arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Rec" ), ( "0", encodeB arg0 ) ]
+        Rec argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Rec" ), ( "0", encodeB argA ) ]
 
-        Gen arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Gen" ), ( "0", Json.Encode.int arg0 ) ]
+        Gen argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Gen" ), ( "0", Json.Encode.int argA ) ]
 
-        Recursive arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Recursive" ), ( "0", encode arg0 ) ]
+        Recursive argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Recursive" ), ( "0", encode argA ) ]
 
 encodeB : B -> Value
 encodeB =

--- a/tests/JsonEncoderCodeGenTest.elm
+++ b/tests/JsonEncoderCodeGenTest.elm
@@ -182,11 +182,11 @@ type Foo
 encode : Foo -> Value
 encode foo =
     case foo of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int argA ) ]
 
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.string arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.string argA ) ]
 """
         , codeGenTest "Picks up an encoder from another file"
             [ elmJson ]
@@ -224,8 +224,8 @@ type B =
 encode : B -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode argA ) ]
 """
         , codeGenTest "Picks up a generator from another file with different import notation"
             [ elmJson ]
@@ -263,8 +263,8 @@ type B =
 encode : B -> Encode.Value
 encode b =
     case b of
-        B arg0 ->
-            Encode.object [ ( "tag", Encode.string "B" ), ( "0", A.encode arg0 ) ]
+        B argA ->
+            Encode.object [ ( "tag", Encode.string "B" ), ( "0", A.encode argA ) ]
 """
         , codeGenTest "Picks up an encoder from another file with generics"
             [ elmJson ]
@@ -302,8 +302,8 @@ type B =
 encode : B -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int argA ) ]
 """
         , codeGenTest "Picks up an encoder from another file with generics type alias"
             [ elmJson ]
@@ -341,8 +341,8 @@ type B =
 encode : B Int -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", A.encode Json.Encode.int argA ) ]
 """
         , codeGenTestFailsWith "Doesn't pick up an encoder if not exposed"
             [ elmJson ]
@@ -440,26 +440,26 @@ type Foo =
 encode : Foo -> Value
 encode b =
     case b of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", encodeA argA ) ]
 
 encodeA : A -> Value
 encodeA arg =
     case arg of
-        A.A arg0 arg1 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB arg0 ), ( "1", encodeC arg1 ) ]
+        A.A argA argB ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB argA ), ( "1", encodeC argB ) ]
 
 encodeB : A.B -> Value
 encodeB arg =
     case arg of
-        A.B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.int arg0 ) ]
+        A.B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.int argA ) ]
 
 encodeC : C.C -> Value
 encodeC arg =
     case arg of
-        C.C arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "C" ), ( "0", Json.Encode.int arg0 ) ]
+        C.C argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "C" ), ( "0", Json.Encode.int argA ) ]
 """
         , codeGenTestFailsWith "Fails when necessary sub-values don't have sufficient visibility"
             [ elmJson ]
@@ -512,8 +512,8 @@ type A =
 encode : A -> Value
 encode arg =
     case arg of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", Json.Encode.int argA ) ]
 
 main =
     Json.Encode.encode 2 (encode (A 2))
@@ -535,11 +535,11 @@ encode encodeVal a =
 encodeResult : (err -> Value) -> (ok -> Value) -> Result err ok -> Value
 encodeResult err ok val =
     case val of
-        Err arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err arg0 ) ]
+        Err argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err argA ) ]
 
-        Ok arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok arg0 ) ]
+        Ok argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok argA ) ]
 """ ]
             """module A exposing (A, encode)
 import Json.Encode exposing (Value)
@@ -551,18 +551,18 @@ type A
 encode : A val -> Value
 encode encodeVal a =
     case a of
-        A arg0 ->
+        A argA ->
             Json.Encode.object
-                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int arg0 ) ]
+                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int argA ) ]
 
 encodeResult : (err -> Value) -> (ok -> Value) -> Result err ok -> Value
 encodeResult err ok val =
     case val of
-        Err arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err arg0 ) ]
+        Err argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", err argA ) ]
 
-        Ok arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok arg0 ) ]
+        Ok argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", ok argA ) ]
 """
         , codeGenTest "Picks up the definition of Result from dependency"
             [ elmJson ]
@@ -588,18 +588,18 @@ type A
 encode : A val -> Value
 encode encodeVal a =
     case a of
-        A arg0 ->
+        A argA ->
             Json.Encode.object
-                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int arg0 ) ]
+                [ ( "tag", Json.Encode.string "A" ), ( "0", encodeResult Json.Encode.string Json.Encode.int argA ) ]
 
 encodeResult : (error -> Value) -> (value -> Value) -> Result error value -> Value
 encodeResult error value arg =
     case arg of
-        Result.Ok arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", value arg0 ) ]
+        Result.Ok argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Ok" ), ( "0", value argA ) ]
 
-        Result.Err arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", error arg0 ) ]
+        Result.Err argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Err" ), ( "0", error argA ) ]
 """
         , codeGenTest "Generates an encoder for a subtype"
             [ elmJson ]
@@ -629,14 +629,14 @@ type B
 encode : A -> Value
 encode arg =
     case arg of
-        A arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB arg0 ) ]
+        A argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "A" ), ( "0", encodeB argA ) ]
 
 encodeB : B -> Value
 encodeB arg =
     case arg of
-        B arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.int arg0 ) ]
+        B argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "B" ), ( "0", Json.Encode.int argA ) ]
 """
         , codeGenTest "recursive"
             [ elmJson ]
@@ -662,12 +662,12 @@ type Tree a
 encode : (a -> Value) -> Tree a -> Value
 encode childEncoder tree =
     case tree of
-        Node arg0 arg1 arg2 ->
+        Node argA argB argC ->
             Encode.object
                 [ ( "tag", Encode.string "Node" )
-                , ( "0", encode childEncoder arg0 )
-                , ( "1", childEncoder arg1 )
-                , ( "2", encode childEncoder arg2 )
+                , ( "0", encode childEncoder argA )
+                , ( "1", childEncoder argB )
+                , ( "2", encode childEncoder argC )
                 ]
 
         Empty ->
@@ -795,8 +795,8 @@ type Always =
 encode : Foo { capabilites | x : Always } -> Value
 encode foo =
     case foo of
-        Foo arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Foo" ), ( "0", Json.Encode.int arg0 ) ]
+        Foo argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Foo" ), ( "0", Json.Encode.int argA ) ]
 """
         , codeGenTest "Generates an encoder with a list"
             [ elmJson ]
@@ -916,14 +916,14 @@ import Json.Encode exposing (Value)
 encode : A Int -> Value
 encode arg =
     case arg of
-        Rec arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Rec" ), ( "0", encodeB arg0 ) ]
+        Rec argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Rec" ), ( "0", encodeB argA ) ]
 
-        Gen arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Gen" ), ( "0", Json.Encode.int arg0 ) ]
+        Gen argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Gen" ), ( "0", Json.Encode.int argA ) ]
 
-        Recursive arg0 ->
-            Json.Encode.object [ ( "tag", Json.Encode.string "Recursive" ), ( "0", encode arg0 ) ]
+        Recursive argA ->
+            Json.Encode.object [ ( "tag", Json.Encode.string "Recursive" ), ( "0", encode argA ) ]
 
 encodeB : B -> Value
 encodeB rec =

--- a/tests/MiniBillCodecCodeGenTest.elm
+++ b/tests/MiniBillCodecCodeGenTest.elm
@@ -153,11 +153,11 @@ codec =
                 VariantA ->
                     variantAEncoder
 
-                VariantB arg0 ->
-                    variantBEncoder arg0
+                VariantB argA ->
+                    variantBEncoder argA
 
-                VariantC arg0 arg1 ->
-                    variantCEncoder arg0 arg1
+                VariantC argA argB ->
+                    variantCEncoder argA argB
         )
         |> Codec.variant0 "VariantA" VariantA
         |> Codec.variant1 "VariantB" VariantB Codec.int
@@ -197,11 +197,11 @@ codec =
                 OtherModule.VariantA ->
                     variantAEncoder
 
-                OtherModule.VariantB arg0 ->
-                    variantBEncoder arg0
+                OtherModule.VariantB argA ->
+                    variantBEncoder argA
 
-                OtherModule.VariantC arg0 ->
-                    variantCEncoder arg0
+                OtherModule.VariantC argA ->
+                    variantCEncoder argA
         )
         |> Codec.variant0 "VariantA" OtherModule.VariantA
         |> Codec.variant1 "VariantB" OtherModule.VariantB Codec.int
@@ -499,11 +499,11 @@ codec codecA =
     Codec.custom
         (\\nodeEncoder leafEncoder value ->
             case value of
-                Node arg0 ->
-                    nodeEncoder arg0
+                Node argA ->
+                    nodeEncoder argA
 
-                Leaf arg0 ->
-                    leafEncoder arg0
+                Leaf argA ->
+                    leafEncoder argA
         )
         |> Codec.variant1 "Node" Node (Codec.lazy (\\() -> codec codecA))
         |> Codec.variant1 "Leaf" Leaf codecA
@@ -604,8 +604,8 @@ routeCodec =
     Codec.custom
         (\\myPagesRouteEncoder value ->
             case value of
-                MyPagesRoute arg0 ->
-                    myPagesRouteEncoder arg0
+                MyPagesRoute argA ->
+                    myPagesRouteEncoder argA
         )
         |> Codec.variant1 "MyPagesRoute" MyPagesRoute (Codec.nullable CaseId.codec)
         |> Codec.buildCustom

--- a/tests/SerializeCodeGenTest.elm
+++ b/tests/SerializeCodeGenTest.elm
@@ -143,11 +143,11 @@ codec =
                 VariantA ->
                     variantAEncoder
 
-                VariantB arg0 ->
-                    variantBEncoder arg0
+                VariantB argA ->
+                    variantBEncoder argA
 
-                VariantC arg0 arg1 ->
-                    variantCEncoder arg0 arg1
+                VariantC argA argB ->
+                    variantCEncoder argA argB
         )
         |> Serialize.variant0 VariantA
         |> Serialize.variant1 VariantB Serialize.int
@@ -187,11 +187,11 @@ codec =
                 OtherModule.VariantA ->
                     variantAEncoder
 
-                OtherModule.VariantB arg0 ->
-                    variantBEncoder arg0
+                OtherModule.VariantB argA ->
+                    variantBEncoder argA
 
-                OtherModule.VariantC arg0 ->
-                    variantCEncoder arg0
+                OtherModule.VariantC argA ->
+                    variantCEncoder argA
         )
         |> Serialize.variant0 OtherModule.VariantA
         |> Serialize.variant1 OtherModule.VariantB Serialize.int
@@ -485,11 +485,11 @@ codec codecA =
     Serialize.customType
         (\\nodeEncoder leafEncoder value ->
             case value of
-                Node arg0 ->
-                    nodeEncoder arg0
+                Node argA ->
+                    nodeEncoder argA
 
-                Leaf arg0 ->
-                    leafEncoder arg0
+                Leaf argA ->
+                    leafEncoder argA
         )
         |> Serialize.variant1 Node (Serialize.lazy (\\() -> codec codecA))
         |> Serialize.variant1 Leaf codecA
@@ -592,8 +592,8 @@ routeCodec =
     Serialize.customType
         (\\myPagesRouteEncoder value ->
             case value of
-                MyPagesRoute arg0 ->
-                    myPagesRouteEncoder arg0
+                MyPagesRoute argA ->
+                    myPagesRouteEncoder argA
         )
         |> Serialize.variant1 MyPagesRoute (Serialize.maybe CaseId.codec)
         |> Serialize.finishCustomType


### PR DESCRIPTION
I'm guessing you don't have any preference between using arg0, arg1, arg2 ... vs using argA, argB, argC ... ? If that's true then I'd like for elm-derive to use letters instead. The reason being that I have an elm-review rule that prevents the user from using "stale references". i.e. if there's a `model2`, you can't use `model`. I find this useful for catching bugs, but it's a bit inconvenient when elm-derive generates arg0 and arg1 and uses both at the same time which my rule flags.